### PR TITLE
docs: raise baseline to Python 3.12

### DIFF
--- a/docs/agentcore-architecture-and-development-plan.md
+++ b/docs/agentcore-architecture-and-development-plan.md
@@ -3248,13 +3248,13 @@ description = "Open-source agent orchestration framework based on A2A protocol"
 readme = "README.md"
 authors = [{name = "AgentCore Team", email = "team@agentcore.ai"}]
 license = {text = "Apache-2.0"}
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 keywords = ["ai", "agents", "orchestration", "a2a", "multi-agent"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
@@ -3355,7 +3355,7 @@ multi_line_output = 3
 line_length = 88
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/docs/breakdown/README.md
+++ b/docs/breakdown/README.md
@@ -119,7 +119,7 @@ graph TD
 ## Getting Started
 
 ### Prerequisites
-- Python 3.11+ with asyncio support
+- Python 3.12+ with asyncio support
 - Docker 24.0+ with security features
 - Kubernetes 1.28+ with Pod Security Standards
 - UV package manager for dependency management

--- a/docs/breakdown/a2a-protocol.md
+++ b/docs/breakdown/a2a-protocol.md
@@ -231,7 +231,7 @@ Relations:
 
 ### Technology Stack
 
-**Runtime:** Python 3.11+ with asyncio support
+**Runtime:** Python 3.12+ with asyncio support
 **Framework:** FastAPI 0.104+ with Uvicorn/Gunicorn production deployment
 **Communication:** fastapi-websocket-rpc for JSON-RPC over WebSocket
 **State Management:** Redis Cluster 7.0+ with Sentinel (minimum 3 masters)

--- a/docs/breakdown/agent-runtime.md
+++ b/docs/breakdown/agent-runtime.md
@@ -207,7 +207,7 @@ Autonomous Pattern:
 
 ```yaml
 SecurityProfile:
-  base_image: "agentcore/hardened-python:3.11"
+  base_image: "agentcore/hardened-python:3.12"
   user_namespace: true
   read_only_filesystem: true
   no_new_privileges: true
@@ -261,7 +261,7 @@ Relations:
 
 **Containerization:** Docker 24.0+ with hardened security profiles and distroless base images
 **Orchestration:** Kubernetes 1.28+ with Pod Security Standards and custom resource definitions
-**Runtime:** Python 3.11+ with asyncio for concurrent agent management
+**Runtime:** Python 3.12+ with asyncio for concurrent agent management
 **Security:** Custom seccomp profiles, user namespace remapping, read-only filesystems
 **State Management:** Redis Cluster for coordination, PostgreSQL for persistence
 **Rationale:** Research shows Docker hardened images provide 95% attack surface reduction, Kubernetes Pod Security Standards enforce container isolation, Python asyncio enables 1000+ concurrent agent execution
@@ -280,7 +280,7 @@ Relations:
 # Environment variables
 KUBERNETES_NAMESPACE: agentcore-runtime
 CONTAINER_REGISTRY: agentcore.azurecr.io
-AGENT_IMAGE_BASE: agentcore/hardened-python:3.11
+AGENT_IMAGE_BASE: agentcore/hardened-python:3.12
 MAX_CONCURRENT_AGENTS: 1000
 AGENT_STARTUP_TIMEOUT: 30
 TOOL_EXECUTION_TIMEOUT: 60

--- a/docs/specs/a2a-protocol/plan.md
+++ b/docs/specs/a2a-protocol/plan.md
@@ -22,7 +22,7 @@ The A2A Protocol Layer serves as the foundational communication infrastructure i
 
 ### Recommended
 
-**Runtime:** Python 3.11+ with asyncio
+**Runtime:** Python 3.12+ with asyncio
 
 - **Rationale:** Native async support required for 10,000+ msg/sec throughput, excellent JSON-RPC libraries (jsonrpcserver), strong typing with Pydantic v2
 - **Research Citation:** FastAPI 2025 benchmarks show 60,000+ req/sec capability with proper async implementation
@@ -281,7 +281,7 @@ class A2AMessage(BaseModel):
 
 **Required Tools and Versions:**
 
-- Python 3.11.5+ with asyncio and type hints
+- Python 3.12.5+ with asyncio and type hints
 - Docker 24.0+ with BuildKit and multi-stage builds
 - UV 0.4+ for dependency management and virtual environments
 - PostgreSQL 14+ with pg_stat_statements extension
@@ -340,7 +340,7 @@ volumes:
 
 **CI/CD Pipeline Requirements:**
 
-- GitHub Actions with matrix testing across Python 3.11-3.12
+- GitHub Actions with matrix testing across Python 3.12+
 - Automated A2A protocol compliance testing against Google reference implementation
 - Security scanning with Trivy and SAST tools
 - Performance regression testing with k6 load tests

--- a/docs/specs/a2a-protocol/spec.md
+++ b/docs/specs/a2a-protocol/spec.md
@@ -260,7 +260,7 @@ The A2A Protocol Layer provides the foundational communication infrastructure fo
 
 ### Technical Assumptions
 
-- Python 3.11+ runtime environment with asyncio support
+- Python 3.12+ runtime environment with asyncio support
 - Redis cluster for distributed session state and caching
 - PostgreSQL database for persistent data storage
 - Docker containerization for deployment and scaling

--- a/docs/specs/agent-runtime/plan.md
+++ b/docs/specs/agent-runtime/plan.md
@@ -27,7 +27,7 @@ The Agent Runtime Layer provides secure, isolated execution environments for mul
 - **Rationale:** Industry-standard isolation with 95% attack surface reduction through Docker Hardened Images (DHI), enterprise-grade security with STIG compliance
 - **Research Citation:** 2025 Docker security research shows hardened images provide near-zero CVEs with 7-day patch SLA and enhanced isolation features
 
-**Runtime Environment:** Python 3.11+ with asyncio for concurrent execution
+**Runtime Environment:** Python 3.12+ with asyncio for concurrent execution
 
 - **Rationale:** Native async support for 1000+ concurrent agents, rich AI/ML ecosystem, excellent debugging and monitoring capabilities
 - **Research Citation:** Python remains dominant AI development language with 80%+ market share and mature containerization support
@@ -318,7 +318,7 @@ class ToolExecutionRequest(BaseModel):
 
 **Required Tools and Versions:**
 
-- Python 3.11.5+ with asyncio and comprehensive typing support
+- Python 3.12.5+ with asyncio and comprehensive typing support
 - Docker 24.0+ with BuildKit, hardened images, and security scanning
 - Kubernetes 1.28+ with Pod Security Standards and network policies
 - UV 0.4+ for rapid dependency management and virtual environment handling

--- a/docs/specs/agent-runtime/spec.md
+++ b/docs/specs/agent-runtime/spec.md
@@ -278,7 +278,7 @@ The Agent Runtime Layer provides secure, isolated execution environments for mul
 
 - Docker 24.0+ with advanced security features and resource constraints
 - Kubernetes or similar container orchestration platform for production deployment
-- Python 3.11+ runtime with asyncio support for concurrent agent management
+- Python 3.12+ runtime with asyncio support for concurrent agent management
 - Redis cluster for distributed state management and coordination
 - PostgreSQL for persistent agent metadata and execution history
 

--- a/docs/specs/dspy-optimization/spec.md
+++ b/docs/specs/dspy-optimization/spec.md
@@ -318,7 +318,7 @@ The DSPy Optimization Engine provides systematic AI optimization capabilities us
 ### Technical Assumptions
 
 - DSPy framework and supporting libraries for optimization algorithms
-- Python 3.11+ with machine learning libraries (numpy, scipy, scikit-learn)
+- Python 3.12+ with machine learning libraries (numpy, scipy, scikit-learn)
 - GPU compute resources for intensive optimization workloads
 - PostgreSQL for optimization history and performance data storage
 - Redis for optimization job queuing and distributed coordination

--- a/docs/specs/gateway-layer/spec.md
+++ b/docs/specs/gateway-layer/spec.md
@@ -248,7 +248,7 @@ X-Client-Version: <version>
 
 ### Technical Assumptions
 - FastAPI framework with Uvicorn/Gunicorn for high-performance async web serving
-- Python 3.11+ with asyncio for concurrent request processing
+- Python 3.12+ with asyncio for concurrent request processing
 - Redis for session state, rate limiting, and distributed caching
 - SSL/TLS certificates for secure communication
 - Load balancer (nginx, HAProxy, or cloud load balancer) for production deployment

--- a/docs/specs/orchestration-engine/spec.md
+++ b/docs/specs/orchestration-engine/spec.md
@@ -285,7 +285,7 @@ workflow:
 ### Technical Assumptions
 - Redis Cluster for distributed workflow state management and event streaming
 - PostgreSQL for persistent workflow definitions and execution history
-- Python 3.11+ with asyncio for high-performance async coordination
+- Python 3.12+ with asyncio for high-performance async coordination
 - Kubernetes for container orchestration and resource management
 - Event streaming platform (Redis Streams or Apache Kafka) for real-time coordination
 


### PR DESCRIPTION
# docs: Raise baseline to Python 3.12

## 🎯 Purpose
Standardize documentation to Python 3.12 to reflect project baseline and ensure consistency across architecture and specs.

## 📝 Changes
### Changed
- Update minimum Python version references from 3.11 to 3.12 across docs
- Adjust classifiers and examples accordingly

## 🔧 Technical Details
**Approach:**
- Single pass update across architecture, breakdown, and specs docs; no code changes.

**Key Files:**
- `docs/agentcore-architecture-and-development-plan.md` – requires-python, classifier, mypy python_version
- `docs/breakdown/README.md` – prerequisites
- `docs/breakdown/a2a-protocol.md` – runtime section
- `docs/breakdown/agent-runtime.md` – base image tags and runtime mentions
- `docs/specs/a2a-protocol/plan.md` – recommended/runtime and CI matrix
- `docs/specs/a2a-protocol/spec.md` – technical assumptions
- `docs/specs/agent-runtime/plan.md` – runtime environment and tool versions
- `docs/specs/agent-runtime/spec.md` – runtime assumptions
- `docs/specs/dspy-optimization/spec.md` – technical assumptions
- `docs/specs/gateway-layer/spec.md` – technical assumptions
- `docs/specs/orchestration-engine/spec.md` – technical assumptions

**Dependencies:**
- None added

## 🧪 Testing
**Test Coverage:**
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual review completed

**Test Scenarios:**
1. Verify all references now point to Python 3.12+
2. Confirm no code or build configs changed

## 📊 Impact
**Performance:**
- None

**Breaking Changes:**
- [x] No breaking changes

**Migration Required:**
- [x] No migration needed

## 🔗 References
- Follows repo guidance for Python baseline alignment

## ✅ Checklist
- [x] Code follows project style guidelines
- [x] Tests pass locally (docs-only)
- [x] Documentation updated
- [x] No console errors/warnings
- [x] Reviewed own changes
- [x] Ready for review

## 📋 Review Notes
Focus on completeness: confirm there are no remaining 3.11 references that should be 3.12 in docs.

---

### Commits in this PR
- `$(git rev-parse --short HEAD)` docs(*): raise baseline to Python 3.12